### PR TITLE
feat: add experimental telescope picker for project selection (`:NeotestPlaywrightProject`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,11 +127,14 @@ require('neotest-playwright').adapter({
 		end,
 
 		experimental = {
-			-- If true, a telescope picker will be used for `:NeotestPlaywrightProject`.
-			-- Otherwise, `vim.ui.select` is used.
-			-- In normal mode, `<Tab>` toggles the project under the cursor.
-			-- `<CR>` (enter key) applies the selection.
-			use_telescope = true,
+			telescope = {
+				-- If true, a telescope picker will be used for `:NeotestPlaywrightProject`.
+				-- Otherwise, `vim.ui.select` is used.
+				-- In normal mode, `<Tab>` toggles the project under the cursor.
+				-- `<CR>` (enter key) applies the selection.
+				enabled = false,
+				opts = {},
+			},
 		},
 	},
 })

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Using lazyvim:
 	'nvim-neotest/neotest',
 	dependencies = {
 		'thenbe/neotest-playwright',
+      dependencies = 'nvim-telescope/telescope.nvim',
 	},
 	config = function()
 		require('neotest').setup({
@@ -124,6 +125,14 @@ require('neotest-playwright').adapter({
 			local result = file_path:find('e2e/tests/.*%.test%.ts$') ~= nil
 			return result
 		end,
+
+		experimental = {
+			-- If true, a telescope picker will be used for `:NeotestPlaywrightProject`.
+			-- Otherwise, `vim.ui.select` is used.
+			-- In normal mode, `<Tab>` toggles the project under the cursor.
+			-- `<CR>` (enter key) applies the selection.
+			use_telescope = true,
+		},
 	},
 })
 ```

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -13,6 +13,7 @@ tasks:
       - rm -rf lua/neotest-playwright
       - tstl -p tsconfig.build.json {{.CLI_ARGS}}
       - cp src/util.lua lua/neotest-playwright/util.lua
+      - cp src/pickers.lua lua/neotest-playwright/pickers.lua
       - cp -r src/consumers lua/neotest-playwright/consumers
       - tsx ./scripts/fix-require-paths.ts
 

--- a/lua/neotest-playwright/adapter-options.lua
+++ b/lua/neotest-playwright/adapter-options.lua
@@ -15,6 +15,6 @@ ____exports.options = {
     extra_args = {},
     tempDataFile = vim.fn.stdpath("data") .. "/neotest-playwright-test-list.json",
     enable_dynamic_test_discovery = false,
-    experimental = {use_telescope = false}
+    experimental = {telescope = {enabled = false, opts = {}}}
 }
 return ____exports

--- a/lua/neotest-playwright/adapter-options.lua
+++ b/lua/neotest-playwright/adapter-options.lua
@@ -14,6 +14,7 @@ ____exports.options = {
     env = {},
     extra_args = {},
     tempDataFile = vim.fn.stdpath("data") .. "/neotest-playwright-test-list.json",
-    enable_dynamic_test_discovery = false
+    enable_dynamic_test_discovery = false,
+    experimental = {use_telescope = false}
 }
 return ____exports

--- a/lua/neotest-playwright/pickers.lua
+++ b/lua/neotest-playwright/pickers.lua
@@ -1,0 +1,121 @@
+local has_telescope, telescope = pcall(require, 'telescope')
+
+if not has_telescope then
+	error('nvim-telescope/telescope.nvim is not installed')
+end
+
+local finders = require('telescope.finders')
+local pickers = require('telescope.pickers')
+local conf = require('telescope.config').values
+local action_state = require('telescope.actions.state')
+local action_utils = require('telescope.actions.utils')
+local actions = require('telescope.actions')
+
+---@alias ProjectName string
+
+---@class NeotestPlaywrightProjectOptions
+---@field prompt string
+---@field choices ProjectName[]
+---@field preselected ProjectName[]
+---@field on_select fun(selected: ProjectName[])
+
+local select_some = function(prompt_bufnr, selections)
+	local current_picker = action_state.get_current_picker(prompt_bufnr)
+	local selections_set = {}
+	for _, selection in ipairs(selections) do
+		selections_set[selection] = true
+	end
+	action_utils.map_entries(prompt_bufnr, function(entry, _, row)
+		if selections_set[entry.value] and not current_picker._multi:is_selected(entry) then
+			current_picker._multi:add(entry)
+			if current_picker:can_select_row(row) then
+				local caret = current_picker:update_prefix(entry, row)
+				if current_picker._selection_entry == entry and current_picker._selection_row == row then
+					current_picker.highlighter:hi_selection(row, caret:match('(.*%S)'))
+				end
+				current_picker.highlighter:hi_multiselect(row, current_picker._multi:is_selected(entry))
+			end
+		end
+	end)
+	current_picker:get_status_updater(current_picker.prompt_win, current_picker.prompt_bufnr)()
+end
+
+---@param np_opts NeotestPlaywrightProjectOptions
+local function show_picker(opts, np_opts)
+	opts = opts or {}
+
+	-- convert `{'PROJECT1', 'PROJECT2'}` to `{{text='PROJECT1'}, {text='PROJECT2'}}`
+	local results = vim
+		.iter(np_opts.choices)
+		:map(function(x)
+			return { text = x }
+		end)
+		:totable()
+
+	local picker = pickers.new(opts, {
+		prompt_title = np_opts.prompt,
+		finder = finders.new_table({
+			results = results,
+			entry_maker = function(entry)
+				return {
+					value = entry.text,
+					display = entry.text,
+					ordinal = entry.text,
+				}
+			end,
+		}),
+		sorter = conf.generic_sorter(opts),
+		attach_mappings = function(prompt_bufnr, map)
+			local picker = action_state.get_current_picker(prompt_bufnr)
+
+			-- Confirm selection on `<CR>`
+			actions.select_default:replace(function()
+				---@type ProjectName[]
+				local selected = {}
+				for _, entry in ipairs(picker:get_multi_selection()) do
+					---@type ProjectName
+					local value = entry.value
+					table.insert(selected, value)
+				end
+				np_opts.on_select(selected)
+				actions.close(prompt_bufnr)
+			end)
+
+			-- Toggle the selection under the cursor
+			map('n', '<Tab>', function()
+				actions.toggle_selection(prompt_bufnr)
+			end)
+
+			-- Load preselected projects into the picker
+			map('n', 'R', function()
+				select_some(prompt_bufnr, np_opts.preselected)
+			end)
+
+			return true
+		end,
+	})
+	picker:find()
+
+	-- Automatically mark the selected options as selected. This function errors
+	-- when called quickly after creating the picker. Therefore, we delay its
+	-- execution a bit.
+	local timer = vim.loop.new_timer()
+	timer:start(
+		70,
+		0,
+		vim.schedule_wrap(function()
+			timer:stop()
+			timer:close()
+			-- `picker.manager` will be false when the picker is first created. We
+			-- need to wait for it to be initialized before attempting to
+			-- `select_some()`.
+			if picker.manager ~= false then
+				select_some(picker.prompt_bufnr, np_opts.preselected)
+			end
+		end)
+	)
+end
+
+local M = {}
+M.show_picker = show_picker
+return M

--- a/lua/neotest-playwright/project.lua
+++ b/lua/neotest-playwright/project.lua
@@ -70,7 +70,7 @@ selectProjects = function(choices, preselected, on_select, use_telescope, telesc
     if telescope_opts == nil then
         telescope_opts = options.experimental.telescope.opts
     end
-    local prompt = "Select projects to include in the next test run:"
+    local prompt = "Select projects to include in the next test run (toggle: <Tab>, apply: <CR>)"
     if use_telescope then
         show_picker(
             telescope_opts,

--- a/lua/neotest-playwright/project.lua
+++ b/lua/neotest-playwright/project.lua
@@ -71,7 +71,7 @@ selectProjects = function(choices, preselected, on_select, use_telescope)
     local prompt = "Select projects to include in the next test run:"
     if use_telescope then
         show_picker(
-            nil,
+            {},
             {
                 prompt = prompt,
                 choices = choices,

--- a/lua/neotest-playwright/project.lua
+++ b/lua/neotest-playwright/project.lua
@@ -57,21 +57,23 @@ ____exports.create_project_command = function()
                     setProjects(selection)
                     logger("info", "selectProjects", selection)
                     vim.api.nvim_command("NeotestPlaywrightRefresh")
-                end,
-                options.experimental.use_telescope
+                end
             )
         end,
         {nargs = 0}
     )
 end
-selectProjects = function(choices, preselected, on_select, use_telescope)
+selectProjects = function(choices, preselected, on_select, use_telescope, telescope_opts)
     if use_telescope == nil then
-        use_telescope = false
+        use_telescope = options.experimental.telescope.enabled
+    end
+    if telescope_opts == nil then
+        telescope_opts = options.experimental.telescope.opts
     end
     local prompt = "Select projects to include in the next test run:"
     if use_telescope then
         show_picker(
-            {},
+            telescope_opts,
             {
                 prompt = prompt,
                 choices = choices,

--- a/scripts/fix-require-paths.ts
+++ b/scripts/fix-require-paths.ts
@@ -8,6 +8,12 @@ const NO_REPLACE = [
 	'neotest.lib',
 	'neotest.logging',
 	'say',
+	'telescope.actions',
+	'telescope.actions.state',
+	'telescope.actions.utils',
+	'telescope.config',
+	'telescope.finders',
+	'telescope.pickers',
 ];
 
 const PREFIX = 'neotest-playwright';

--- a/src/adapter-options.ts
+++ b/src/adapter-options.ts
@@ -14,6 +14,9 @@ export const options: Adapter['options'] = {
 	tempDataFile: vim.fn.stdpath('data') + '/neotest-playwright-test-list.json',
 	enable_dynamic_test_discovery: false,
 	experimental: {
-		use_telescope: false,
+		telescope: {
+			enabled: false,
+			opts: {},
+		},
 	},
 };

--- a/src/adapter-options.ts
+++ b/src/adapter-options.ts
@@ -13,4 +13,7 @@ export const options: Adapter['options'] = {
 	extra_args: [],
 	tempDataFile: vim.fn.stdpath('data') + '/neotest-playwright-test-list.json',
 	enable_dynamic_test_discovery: false,
+	experimental: {
+		use_telescope: false,
+	},
 };

--- a/src/pickers.lua
+++ b/src/pickers.lua
@@ -1,0 +1,121 @@
+local has_telescope, telescope = pcall(require, 'telescope')
+
+if not has_telescope then
+	error('nvim-telescope/telescope.nvim is not installed')
+end
+
+local finders = require('telescope.finders')
+local pickers = require('telescope.pickers')
+local conf = require('telescope.config').values
+local action_state = require('telescope.actions.state')
+local action_utils = require('telescope.actions.utils')
+local actions = require('telescope.actions')
+
+---@alias ProjectName string
+
+---@class NeotestPlaywrightProjectOptions
+---@field prompt string
+---@field choices ProjectName[]
+---@field preselected ProjectName[]
+---@field on_select fun(selected: ProjectName[])
+
+local select_some = function(prompt_bufnr, selections)
+	local current_picker = action_state.get_current_picker(prompt_bufnr)
+	local selections_set = {}
+	for _, selection in ipairs(selections) do
+		selections_set[selection] = true
+	end
+	action_utils.map_entries(prompt_bufnr, function(entry, _, row)
+		if selections_set[entry.value] and not current_picker._multi:is_selected(entry) then
+			current_picker._multi:add(entry)
+			if current_picker:can_select_row(row) then
+				local caret = current_picker:update_prefix(entry, row)
+				if current_picker._selection_entry == entry and current_picker._selection_row == row then
+					current_picker.highlighter:hi_selection(row, caret:match('(.*%S)'))
+				end
+				current_picker.highlighter:hi_multiselect(row, current_picker._multi:is_selected(entry))
+			end
+		end
+	end)
+	current_picker:get_status_updater(current_picker.prompt_win, current_picker.prompt_bufnr)()
+end
+
+---@param np_opts NeotestPlaywrightProjectOptions
+local function show_picker(opts, np_opts)
+	opts = opts or {}
+
+	-- convert `{'PROJECT1', 'PROJECT2'}` to `{{text='PROJECT1'}, {text='PROJECT2'}}`
+	local results = vim
+		.iter(np_opts.choices)
+		:map(function(x)
+			return { text = x }
+		end)
+		:totable()
+
+	local picker = pickers.new(opts, {
+		prompt_title = np_opts.prompt,
+		finder = finders.new_table({
+			results = results,
+			entry_maker = function(entry)
+				return {
+					value = entry.text,
+					display = entry.text,
+					ordinal = entry.text,
+				}
+			end,
+		}),
+		sorter = conf.generic_sorter(opts),
+		attach_mappings = function(prompt_bufnr, map)
+			local picker = action_state.get_current_picker(prompt_bufnr)
+
+			-- Confirm selection on `<CR>`
+			actions.select_default:replace(function()
+				---@type ProjectName[]
+				local selected = {}
+				for _, entry in ipairs(picker:get_multi_selection()) do
+					---@type ProjectName
+					local value = entry.value
+					table.insert(selected, value)
+				end
+				np_opts.on_select(selected)
+				actions.close(prompt_bufnr)
+			end)
+
+			-- Toggle the selection under the cursor
+			map('n', '<Tab>', function()
+				actions.toggle_selection(prompt_bufnr)
+			end)
+
+			-- Load preselected projects into the picker
+			map('n', 'R', function()
+				select_some(prompt_bufnr, np_opts.preselected)
+			end)
+
+			return true
+		end,
+	})
+	picker:find()
+
+	-- Automatically mark the selected options as selected. This function errors
+	-- when called quickly after creating the picker. Therefore, we delay its
+	-- execution a bit.
+	local timer = vim.loop.new_timer()
+	timer:start(
+		70,
+		0,
+		vim.schedule_wrap(function()
+			timer:stop()
+			timer:close()
+			-- `picker.manager` will be false when the picker is first created. We
+			-- need to wait for it to be initialized before attempting to
+			-- `select_some()`.
+			if picker.manager ~= false then
+				select_some(picker.prompt_bufnr, np_opts.preselected)
+			end
+		end)
+	)
+end
+
+local M = {}
+M.show_picker = show_picker
+return M

--- a/src/project.ts
+++ b/src/project.ts
@@ -1,4 +1,5 @@
 import type * as P from '@playwright/test/reporter';
+import { show_picker } from 'neotest-playwright.pickers';
 import { options } from './adapter-options';
 import { logger } from './logging';
 import { loadProjectCache, saveProjectCache } from './persist';
@@ -34,20 +35,27 @@ export const create_project_command = () => {
 
 			const choices = parseProjects(output);
 
-			let preselected = null;
+			let preselected: string[] = [];
 
 			// if options.persist_project_selection is false, avoid loading from cache
 			// even if it exists
 			if (options.persist_project_selection) {
-				preselected = loadPreselectedProjects();
+				preselected = loadPreselectedProjects() ?? [];
 			}
 
-			const selection = selectProjects(choices, preselected);
+			selectProjects(
+				choices,
+				preselected,
+				(selection) => {
+					setProjects(selection);
 
-			setProjects(selection);
+					logger('info', 'selectProjects', selection);
 
-			// trigger data refresh in subprocess
-			vim.api.nvim_command('NeotestPlaywrightRefresh');
+					// trigger data refresh in subprocess
+					vim.api.nvim_command('NeotestPlaywrightRefresh');
+				},
+				options.experimental.use_telescope,
+			);
 		},
 		{
 			nargs: 0,
@@ -55,20 +63,30 @@ export const create_project_command = () => {
 	);
 };
 
-const selectProjects = (choices: string[], preselected: string[] | null) => {
+const selectProjects = (
+	choices: string[],
+	preselected: string[],
+	on_select: (selection: string[]) => void,
+	use_telescope = false,
+) => {
 	const prompt = 'Select projects to include in the next test run:';
 
-	const choice = selectMultiple({
-		prompt,
-		choices,
-		initial: 'all',
-		preselected,
-	});
-
-	logger('debug', 'selectProjects', choice);
-
-	// TODO: rm type cast
-	return choice as string[];
+	if (use_telescope) {
+		show_picker(null, {
+			prompt: prompt,
+			choices: choices,
+			preselected: preselected,
+			on_select: (selection) => on_select(selection),
+		});
+	} else {
+		const choice = selectMultiple({
+			prompt,
+			choices,
+			initial: 'all',
+			preselected,
+		});
+		on_select(choice as string[]);
+	}
 };
 
 const setProjects = (projects: string[]) => {

--- a/src/project.ts
+++ b/src/project.ts
@@ -43,19 +43,14 @@ export const create_project_command = () => {
 				preselected = loadPreselectedProjects() ?? [];
 			}
 
-			selectProjects(
-				choices,
-				preselected,
-				(selection) => {
-					setProjects(selection);
+			selectProjects(choices, preselected, (selection) => {
+				setProjects(selection);
 
-					logger('info', 'selectProjects', selection);
+				logger('info', 'selectProjects', selection);
 
-					// trigger data refresh in subprocess
-					vim.api.nvim_command('NeotestPlaywrightRefresh');
-				},
-				options.experimental.use_telescope,
-			);
+				// trigger data refresh in subprocess
+				vim.api.nvim_command('NeotestPlaywrightRefresh');
+			});
 		},
 		{
 			nargs: 0,
@@ -67,20 +62,18 @@ const selectProjects = (
 	choices: string[],
 	preselected: string[],
 	on_select: (selection: string[]) => void,
-	use_telescope = false,
+	use_telescope = options.experimental.telescope.enabled,
+	telescope_opts = options.experimental.telescope.opts,
 ) => {
 	const prompt = 'Select projects to include in the next test run:';
 
 	if (use_telescope) {
-		show_picker(
-			{},
-			{
-				prompt: prompt,
-				choices: choices,
-				preselected: preselected,
-				on_select: (selection) => on_select(selection),
-			},
-		);
+		show_picker(telescope_opts, {
+			prompt: prompt,
+			choices: choices,
+			preselected: preselected,
+			on_select: (selection) => on_select(selection),
+		});
 	} else {
 		const choice = selectMultiple({
 			prompt,

--- a/src/project.ts
+++ b/src/project.ts
@@ -65,7 +65,8 @@ const selectProjects = (
 	use_telescope = options.experimental.telescope.enabled,
 	telescope_opts = options.experimental.telescope.opts,
 ) => {
-	const prompt = 'Select projects to include in the next test run:';
+	const prompt =
+		'Select projects to include in the next test run (toggle: <Tab>, apply: <CR>)';
 
 	if (use_telescope) {
 		show_picker(telescope_opts, {

--- a/src/project.ts
+++ b/src/project.ts
@@ -72,12 +72,15 @@ const selectProjects = (
 	const prompt = 'Select projects to include in the next test run:';
 
 	if (use_telescope) {
-		show_picker(null, {
-			prompt: prompt,
-			choices: choices,
-			preselected: preselected,
-			on_select: (selection) => on_select(selection),
-		});
+		show_picker(
+			{},
+			{
+				prompt: prompt,
+				choices: choices,
+				preselected: preselected,
+				on_select: (selection) => on_select(selection),
+			},
+		);
 	} else {
 		const choice = selectMultiple({
 			prompt,

--- a/src/types/adapter.ts
+++ b/src/types/adapter.ts
@@ -23,7 +23,12 @@ export interface AdapterOptions {
 	/** Override the default filter_dir function. */
 	filter_dir?: Adapter['filter_dir'];
 	/** Override the default is_test_file function. */
-	is_test_file?: Adapter['is_test_file']
+	is_test_file?: Adapter['is_test_file'];
+	experimental: {
+		/** If true, a telescope picker will be used for project selection. Otherwise,
+		 * `vim.ui.select` is used.  */
+		use_telescope: boolean;
+	};
 }
 
 export type AdapterData =

--- a/src/types/adapter.ts
+++ b/src/types/adapter.ts
@@ -25,9 +25,12 @@ export interface AdapterOptions {
 	/** Override the default is_test_file function. */
 	is_test_file?: Adapter['is_test_file'];
 	experimental: {
-		/** If true, a telescope picker will be used for project selection. Otherwise,
-		 * `vim.ui.select` is used.  */
-		use_telescope: boolean;
+		telescope: {
+			/** If true, a telescope picker will be used for project selection. Otherwise,
+			 * `vim.ui.select` is used.  */
+			enabled: boolean;
+			opts: Record<string, unknown>;
+		};
 	};
 }
 

--- a/src/types/pickers.d.ts
+++ b/src/types/pickers.d.ts
@@ -1,0 +1,12 @@
+declare module 'neotest-playwright.pickers' {
+	/** Shows a project picker. */
+	const show_picker: (
+		opts: Record<string, unknown> | null,
+		np_opts: {
+			prompt: string;
+			choices: string[];
+			preselected: string[];
+			on_select: (this: void, selection: string[]) => void;
+		},
+	) => void;
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -16,6 +16,7 @@
 			"neotest.async",
 			"neotest.lib",
 			"neotest.logging",
+			"neotest-playwright.pickers", // copied manually
 			"neotest-playwright.util" // copied manually
 		]
 	}


### PR DESCRIPTION
closes #20 
closes #29

Feedback welcome. To test this PR:

```diff
{
	'nvim-neotest/neotest',
	dependencies = {
+		{
			'thenbe/neotest-playwright',
+			branch = 'telescope',
+			dependencies = 'nvim-telescope/telescope.nvim',
+		},
	},
	config = function()
		require('neotest').setup({
			adapters = {
				require('neotest-playwright').adapter({
					options = {
						-- persist_project_selection...,
+						experimental = {
+							-- If true, a telescope picker will be used for `:NeotestPlaywrightProject`.
+							-- Otherwise, `vim.ui.select` is used.
+							-- In normal mode, `<Tab>` toggles the project under the cursor.
+							-- `<CR>` (enter key) applies the selection.
+							telescope = {
+								enabled = true,
+								opts = {},
+							},
+						},
					},
				}),
			},
		})
	end,
}
```
